### PR TITLE
Remove git-lfs, and update link formatting in README

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-*.tif filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text
-*.mp4 filter=lfs diff=lfs merge=lfs -text
-*.mov filter=lfs diff=lfs merge=lfs -text
-*.mrc filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the full [installation guide here](install.md).
 
 ## How to use
 
-The user documentation is available at https://cryostem-tools.github.io/GoldDigger/, including a [user guide](user_guide.md).
+The user documentation is available at [https://cryostem-tools.github.io/GoldDigger/](https://cryostem-tools.github.io/GoldDigger/), including a [user guide](user_guide.md).
 
 ## Citation
 


### PR DESCRIPTION
The automatic website build with mkdocs was failing over on the other (Checkers) repository. I figured out it was failing because git-lfs was not installed on the github CI runner, and the simplest thing to do was just remove git-lfs for now. We're not really using it, so that makes the most sense.

This PR is to make sure we don't have the same problem in this repository.